### PR TITLE
Misc: Django 5.2 update

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -62,22 +62,24 @@ jobs:
       matrix:
         python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         # build LTS version, next version, HEAD
-        django: ["32", "42", "50", "main"]
+        django: ["42", "50", "52", "main"]
         exclude:
           - python: "3.8"
             django: "50"
           - python: "3.8"
+            django: "52"
+          - python: "3.8"
             django: "main"
           - python: "3.9"
             django: "50"
+          - python: "3.9"
+            django: "52"
           - python: "3.9"
             django: "main"
           - python: "3.10"
             django: "main"
           - python: "3.11"
-            django: "32"
-          - python: "3.12"
-            django: "32"
+            django: "main"
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,10 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+        name: ruff (fix)
+      - id: ruff
+        args: [--select=ALL]
+        name: ruff (check)
 
   # python static type checking
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,6 @@
 line-length = 88
+
+[lint]
 ignore = [
     "D100",  # Missing docstring in public module
     "D101",  # Missing docstring in public class
@@ -34,13 +36,13 @@ select = [
     "W",  # pycodestype (warnings)
 ]
 
-[isort]
+[lint.isort]
 combine-as-imports = true
 
-[mccabe]
+[lint.mccabe]
 max-complexity = 8
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "*tests/*" = [
     "D205",  # 1 blank line required between summary line and description
     "D400",  # First line should end with a period

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.4
+
+* Add Django 5.2 to build matrix
+* Drop support for Django versions before 4.2
+* Update ruff commands to use modern "ruff check" syntax
+* Update GitHub Actions to only test Django main branch with Python 3.12
+
 ## v0.3
 
 * Add Django 5.0 to build matrix

--- a/README
+++ b/README
@@ -2,6 +2,12 @@
 
 Django management command for monitoring file diffs.
 
+## Compatibility
+
+Supports:
+- Django 4.2, 5.0, 5.2
+- Python 3.8 to 3.12 (depending on Django version)
+
 ## Background
 
 With a large codebase, and a high velocity team making edits, it can be

--- a/project_checks/management/commands/base.py
+++ b/project_checks/management/commands/base.py
@@ -86,7 +86,8 @@ class DiffCheckCommand(BaseCommand):
         """Dump the contents to stdout."""
         if contents:
             self.stdout.write("--- Contents ---")
-            self.stdout.writelines(contents)
+            for line in contents:
+                self.stdout.write(line + "\n")
         else:
             self.stdout.write("No contents found.")
         self.stdout.write("")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-project-checks"
-version = "0.3"
+version = "0.4"
 description = "Django management commands used to output useful project information."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -12,11 +12,9 @@ documentation = "https://github.com/yunojuno/poetry-template"
 classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.2",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
@@ -30,7 +28,7 @@ packages = [{ include = "project_checks" }]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django = "^3.2 || ^4.0 || ^5.0"
+django = "^4.2 || ^5.0"
 
 [tool.poetry.dev-dependencies]
 black = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,10 @@ envlist =
     fmt, lint, mypy,
     django-checks,
     ; https://docs.djangoproject.com/en/5.0/releases/
-    django32-py{38,39,310}
-    django40-py{38,39,310}
-    django41-py{38,39,310,311}
     django42-py{38,39,310,311}
     django50-py{310,311,312}
-    djangomain-py{311,312}
+    django52-py{310,311,312}
+    djangomain-py312
 
 [testenv]
 deps =
@@ -17,11 +15,9 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
-    django50: https://github.com/django/django/archive/stable/5.0.x.tar.gz
+    django50: Django>=5.0,<5.1
+    django52: https://github.com/django/django/archive/stable/5.2.x.tar.gz
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =
@@ -48,7 +44,7 @@ deps =
     ruff
 
 commands =
-    ruff project_checks
+    ruff check project_checks
 
 [testenv:mypy]
 description = Python source code type hints (mypy)


### PR DESCRIPTION
# Django 5.2 Compatibility Update
This PR updates the project to support Django 5.2 and makes several modernization improvements.

## Changes

1. Added Django 5.2 compatibility
2. Deprecated support for Django versions before 4.2 (removing 3.2, 4.0, 4.1)
3. Updated tox configuration to test against supported Django versions
4. Ensured Django main branch is only tested on Python 3.12
5. Updated GitHub Actions workflow matrix to reflect Django version changes

Also: Addressed an issue where tests were failing in Django 5.2 due to a change in output handling. In previous Django versions, `writelines()` would implicitly add newlines between elements. But Django 5.2 aligns with Python's standard behavior where it doesn't. Fixed by explicitly adding newlines when outputting content in the `print_contents()` method of `DiffCheckCommand`, ensuring consistent behavior across all supported Django versions and keeping the test passing.

### Tooling Improvements

1. Updated ruff commands to use modern ruff check syntax
2. Modernized ruff configuration in .ruff.toml to use new section-based format
3. Updated pre-commit configuration to add explicit ruff check hooks

### Documentation

1. Updated README with compatibility information
2. Updated CHANGELOG to document version 0.4 changes
3. Bumped project version from 0.3 to 0.4 in pyproject.toml
4. Updated pyproject.toml classifiers to reflect supported Django versions